### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+.gitattributes export-ignore
+.gitignore export-ignore


### PR DESCRIPTION
Adds a basic .gitattributes into the `master` branch used to enforce Unix line feeds and ignore some other miscellaneous files from release packages, will be extended in the future for sure.