### PR TITLE
Extend readme with acknowledgements

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,10 @@ sub MAIN($token) {
     }
 }
 ```
+
+## Acknowledgements
+
+- [Jonathan 'jnthn' Worthington](https://github.com/jnthn) - answered many of our inane questions in the #perl6 Freenode IRC
+- [Timo 'timotimo' Paulssen](https://github.com/timo) - also answered a great deal of technical questions when jnthn wasn't fast enough :P
+- [Tomislav 'Novica' Novački](https://www.instagram.com/novackinet) - provided our lovely graphics for `API::Discord` and other projects
+- [Yumi 'Yumi' Hirasawa](http://peachyalice.tumblr.com) - inspired us to write `API::Discord` and `Bot::Discord::Yxmi` in the first place


### PR DESCRIPTION
Extends the `README.md` file with some acknowledgements to thank people who helped us in special ways with this project. PR to the `example` branch purely because I already accidentally extended this file once there so might as well keep it consistent.